### PR TITLE
Fix issue #35 regarding fbx2gltf converter

### DIFF
--- a/tools/fbx2gltf.py
+++ b/tools/fbx2gltf.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # ############################################
 # fbx to glTF2.0 converter
 # glTF spec : https://github.com/KhronosGroup/glTF/blob/master/specification/2.0

--- a/tools/fbx2gltf.py
+++ b/tools/fbx2gltf.py
@@ -1235,6 +1235,19 @@ def CorrectImagesPaths(pFilePath):
         lUri = FindFileInDir(os.path.basename(lUri), lFileDir)
         if lUri:
             lRelUri = os.path.relpath(lUri, lFileDir)
+            # If an alternative output directory is specified, copy all textures to output directory
+            if args.output:
+                lOutputDir = os.path.dirname(args.output)
+                print(lOutputDir)
+                # If textures are in a dir and that dir does not yet exist, create it
+                lRelTextureDir = os.path.dirname(lRelUri)
+                print("lRelTextureDir = " + lRelTextureDir)
+                lFullTextureDir = os.path.join(lOutputDir, lRelTextureDir)
+                print("lFullTextureDir = " + lFullTextureDir)
+                if not os.path.exists(lFullTextureDir):
+                    os.makedirs(lFullTextureDir)
+                shutil.copyfile(lUri, os.path.join(lOutputDir, lRelUri))
+                print('Textures copied to output folder')
             if not lRelUri == lGLTFImage['uri']:
                 print('Changed texture file path from "' + lGLTFImage['uri'] + '" to "' + lRelUri + '"')
             lGLTFImage['uri'] = lRelUri

--- a/tools/fbx2gltf.py
+++ b/tools/fbx2gltf.py
@@ -1221,6 +1221,8 @@ def GetNodeIdx(pNode):
 
 
 def FindFileInDir(pFileName, pDir):
+    print("pFileName = " + pFileName)
+    print("pDir = " + pDir)
     for root, dirs, files in os.walk(pDir):
         for file in files:
             if file == pFileName:
@@ -1228,13 +1230,23 @@ def FindFileInDir(pFileName, pDir):
 
 def CorrectImagesPaths(pFilePath):
     lFileFullPath = os.path.join(os.getcwd(), pFilePath)
-    lFileDir = os.path.dirname(lFileFullPath)
+    lFileExtension = pFilePath.rsplit('.', 1)[1].lower()
+    print("lFileExtension = " + lFileExtension)
+    print("lFileFullPath = " + lFileFullPath)
     for lGLTFImage in lib_images:
         lUri = lGLTFImage['uri']
         lUri = lUri.replace(r'[\\\/]+', os.path.sep)
+        if lFileExtension == 'zip':
+            lFileDir = os.path.dirname(lGLTFImage['uri'])
+        else:
+            lFileDir = os.path.dirname(lFileFullPath)
+        print("lFileDir = " + lFileDir)
         lUri = FindFileInDir(os.path.basename(lUri), lFileDir)
+        lUriMine = str(lUri)
+        print("lUriMine = " + lUriMine)
         if lUri:
             lRelUri = os.path.relpath(lUri, lFileDir)
+            print("lRelUri = " + str(lRelUri) )
             # If an alternative output directory is specified, copy all textures to output directory
             if args.output:
                 lOutputDir = os.path.dirname(args.output)

--- a/tools/fbx2gltf.py
+++ b/tools/fbx2gltf.py
@@ -1221,45 +1221,35 @@ def GetNodeIdx(pNode):
 
 
 def FindFileInDir(pFileName, pDir):
-    print("pFileName = " + pFileName)
-    print("pDir = " + pDir)
     for root, dirs, files in os.walk(pDir):
         for file in files:
             if file == pFileName:
                 return os.path.join(root, file)
 
+
 def CorrectImagesPaths(pFilePath):
     lFileFullPath = os.path.join(os.getcwd(), pFilePath)
     lFileExtension = pFilePath.rsplit('.', 1)[1].lower()
-    print("lFileExtension = " + lFileExtension)
-    print("lFileFullPath = " + lFileFullPath)
     for lGLTFImage in lib_images:
         lUri = lGLTFImage['uri']
         lUri = lUri.replace(r'[\\\/]+', os.path.sep)
+        # FBX SDK extracts zip input files to temp folder, so use lGLTFImage uri instead to find temp folder
         if lFileExtension == 'zip':
             lFileDir = os.path.dirname(lGLTFImage['uri'])
         else:
             lFileDir = os.path.dirname(lFileFullPath)
-        print("lFileDir = " + lFileDir)
         lUri = FindFileInDir(os.path.basename(lUri), lFileDir)
-        lUriMine = str(lUri)
-        print("lUriMine = " + lUriMine)
         if lUri:
             lRelUri = os.path.relpath(lUri, lFileDir)
-            print("lRelUri = " + str(lRelUri) )
             # If an alternative output directory is specified, copy all textures to output directory
             if args.output:
                 lOutputDir = os.path.dirname(args.output)
-                print(lOutputDir)
                 # If textures are in a dir and that dir does not yet exist, create it
                 lRelTextureDir = os.path.dirname(lRelUri)
-                print("lRelTextureDir = " + lRelTextureDir)
                 lFullTextureDir = os.path.join(lOutputDir, lRelTextureDir)
-                print("lFullTextureDir = " + lFullTextureDir)
                 if not os.path.exists(lFullTextureDir):
                     os.makedirs(lFullTextureDir)
                 shutil.copyfile(lUri, os.path.join(lOutputDir, lRelUri))
-                print('Textures copied to output folder')
             if not lRelUri == lGLTFImage['uri']:
                 print('Changed texture file path from "' + lGLTFImage['uri'] + '" to "' + lRelUri + '"')
             lGLTFImage['uri'] = lRelUri

--- a/tools/fbx2gltf.py
+++ b/tools/fbx2gltf.py
@@ -1243,7 +1243,7 @@ def CorrectImagesPaths(pFilePath):
         if lUri:
             lRelUri = os.path.relpath(lUri, lFileDir)
             # If an alternative output directory is specified, copy all textures to output directory
-            if args.output:
+            if lOutputDirSpecified:
                 lOutputDir = os.path.dirname(args.output)
                 # If textures are in a dir and that dir does not yet exist, create it
                 lRelTextureDir = os.path.dirname(lRelUri)
@@ -1467,11 +1467,14 @@ if __name__ == "__main__":
         lDuration = float(lTimeRange[1])
 
     if not args.output:
+        lOutputDirSpecified = False
         lBasename, lExt = os.path.splitext(args.file)
         if args.binary:
             args.output = lBasename + '.glb'
         else:
             args.output = lBasename + '.gltf'
+    else:
+        lOutputDirSpecified = True
 
     # PENDING Not use INFINITY poseTime or some joint transform without animation maybe not right.
     lPoseTime = FbxTime()


### PR DESCRIPTION
Textures are now copied correctly when alternative output directory is specified with `-o`, and when input file is a zip. So this solves number 1 and 3 in [issue #35 of clay-viewer](https://github.com/pissang/clay-viewer/issues/35)