### PR TITLE
Import shutil to enable copying of texture files

### DIFF
--- a/tools/fbx2gltf.py
+++ b/tools/fbx2gltf.py
@@ -6,7 +6,7 @@
 # TODO: texture flipY?
 # http://github.com/pissang/
 # ############################################
-import sys, struct, json, os.path, math, argparse
+import sys, struct, json, os.path, math, argparse, shutil
 
 try:
     from FbxCommon import *


### PR DESCRIPTION
I forgot to commit the importing of `shutil`, which is necessary to fire the copyfile command.