### PR TITLE
Set alphaCutoff default value to 0.5

### DIFF
--- a/src/loader/GLTF.js
+++ b/src/loader/GLTF.js
@@ -795,7 +795,7 @@ function () {
             roughness: metallicRoughnessMatInfo.roughnessFactor || 0,
             emission: materialInfo.emissiveFactor || [0, 0, 0],
             emissionIntensity: 1,
-            alphaCutoff: materialInfo.alphaCutoff || 0,
+            alphaCutoff: materialInfo.alphaCutoff || 0.5,
             normalScale: normalScale
         };
         if (commonProperties.roughnessMap) {
@@ -894,7 +894,7 @@ function () {
             glossiness: specularGlossinessMatInfo.glossinessFactor || 0,
             emission: materialInfo.emissiveFactor || [0, 0, 0],
             emissionIntensity: 1,
-            alphaCutoff: materialInfo.alphaCutoff == null ? 0.9 : materialInfo.alphaCutoff
+            alphaCutoff: materialInfo.alphaCutoff == null ? 0.5 : materialInfo.alphaCutoff
         };
         if (commonProperties.glossinessMap) {
             // Ignore specularFactor


### PR DESCRIPTION
Hi there, 

I am sending a PR to change the alphaCutoff default value in glTF loader.

According to GLTF 2.0 spec, the default value of **alphaCutoff** is 0.5
https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/material.schema.json

Please see the following screenshot:
https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/AlphaBlendModeTest

Thank you for making this wonderful renderer, it's very easy to use!
