### PR TITLE
Fix typo in value copy function.

### DIFF
--- a/src/GeometryBase.js
+++ b/src/GeometryBase.js
@@ -82,7 +82,7 @@ function Attribute(name, type, size, semantic) {
             };
             // Copy from source to target
             this.copy = function (target, source) {
-                this.value[target] = this.value[target];
+                this.value[target] = this.value[source];
             };
             break;
         case 2:


### PR DESCRIPTION
A type on array index. It should copy from source to target.