### PR TITLE
Fix bug to get correct bounding box of a mesh node.

### DIFF
--- a/src/Renderable.js
+++ b/src/Renderable.js
@@ -120,10 +120,6 @@ var Renderable = Node.extend(/** @lends clay.Renderable# */ {
 
     getBoundingBox: function (filter, out) {
         out = Node.prototype.getBoundingBox.call(this, filter, out);
-        if (this.geometry && this.geometry.boundingBox) {
-            out.union(this.geometry.boundingBox);
-        }
-
         return out;
     },
 


### PR DESCRIPTION
When we call `Node.prototype.getBoundingBox` to get the bounding box of a node contains geometry (mesh), the returned bounding box has applied world transform of that node. So that it shouldn't union with bounding box of geometry. 

Unless there are other cases in which we do need to do union. Please advice. Thanks.