### PR TITLE
Normalize panning direction.

### DIFF
--- a/src/plugin/OrbitControl.js
+++ b/src/plugin/OrbitControl.js
@@ -531,8 +531,8 @@ var OrbitControl = Base.extend(function () {
 
         // PENDING
         this._center
-            .scaleAndAdd(xAxis, -velocity.x * len / 200)
-            .scaleAndAdd(yAxis, -velocity.y * len / 200);
+            .scaleAndAdd(xAxis.normalize(), -velocity.x * len / 200)
+            .scaleAndAdd(yAxis.normalize(), -velocity.y * len / 200);
 
         this._vectorDamping(velocity, 0);
 


### PR DESCRIPTION
Do normalization on panning direction. I think this should be a propal practice to make panning works regardless scale of scene node and camera node.

In our case we need to scale down whole scene node to make it works with MapBox(Maybe it is.) Panning velocity changes if directions not been normalized.