### PR TITLE
Ceil mipmap size to 1

### DIFF
--- a/src/Texture2D.js
+++ b/src/Texture2D.js
@@ -117,8 +117,8 @@ var Texture2D = Texture.extend(function () {
             for (var i = 0; i < this.mipmaps.length; i++) {
                 var mipmap = this.mipmaps[i];
                 this._updateTextureData(_gl, mipmap, i, width, height, glFormat, glType, false);
-                width /= 2;
-                height /= 2;
+                width = Math.ceil(width / 2);
+                height = Math.ceil(height / 2);
             }
         }
         else {

--- a/src/Texture2D.js
+++ b/src/Texture2D.js
@@ -117,8 +117,8 @@ var Texture2D = Texture.extend(function () {
             for (var i = 0; i < this.mipmaps.length; i++) {
                 var mipmap = this.mipmaps[i];
                 this._updateTextureData(_gl, mipmap, i, width, height, glFormat, glType, false);
-                width = Math.max(width / 2);
-                height = Math.max(height / 2);
+                width = Math.max(width / 2, 1);
+                height = Math.max(height / 2, 1);
             }
         }
         else {

--- a/src/Texture2D.js
+++ b/src/Texture2D.js
@@ -117,8 +117,8 @@ var Texture2D = Texture.extend(function () {
             for (var i = 0; i < this.mipmaps.length; i++) {
                 var mipmap = this.mipmaps[i];
                 this._updateTextureData(_gl, mipmap, i, width, height, glFormat, glType, false);
-                width = Math.ceil(width / 2);
-                height = Math.ceil(height / 2);
+                width = Math.max(width / 2);
+                height = Math.max(height / 2);
             }
         }
         else {


### PR DESCRIPTION
This fix resolves the issue when the width and height are not equal, like 16 x 128.

Size of levels supposed to be: 

`16 x 128, 8 x 64, 4 x 32, 2 x 16, 1 x 8, 1 x 4, 1 x 2, 1 x 1.`
