### PR TITLE
fix: CSP Security hole in tryConvertExpr (new Function(...))

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "rollup-plugin-commonjs": "^8.2.6",
     "rollup-watch": "^4.3.1"
   },
-  "dependencies": {}
+  "dependencies": {
+    "esprima": "^4.0.1",
+    "math-expression-evaluator": "^2.0.3"
+  }
 }


### PR DESCRIPTION
Addresses the CSP security hole identified in the issue linked below and allow ClayGL to be used on sites with strict Content Security Policies:

[Please make claygl CSP compatible when "script-src unsafe-eval" is used](https://github.com/pissang/claygl/issues/133).